### PR TITLE
[Fixed] Handling of public git URLs

### DIFF
--- a/lib/gitify.js
+++ b/lib/gitify.js
@@ -135,7 +135,9 @@ function getRemoteUrl (dir) {
   let packageUrl     = dottie.get(packageContent, 'repository.url');
 
   if (packageUrl) {
-    return packageUrl.replace('git://github.com', 'git+ssh://git@github.com');
+    return packageUrl
+      .replace('git://github.com', 'git+ssh://git@github.com')
+      .replace('git+https://github.com', 'https://github.com');
   }
 }
 

--- a/test/fixtures/demo/npm-shrinkwrap.json
+++ b/test/fixtures/demo/npm-shrinkwrap.json
@@ -2,17 +2,24 @@
   "name": "demo",
   "version": "1.0.0",
   "npm-shrinkwrap-version": "5.4.0",
-  "node-version": "v4.2.4",
+  "node-version": "v4.3.1",
   "dependencies": {
     "keepachangelog": {
-      "version": "0.7.0-1-gbb74726",
-      "resolved": "git+ssh://git@github.com/contentful-labs/keepachangelog.git#v0.7.0-1-gbb74726",
+      "version": "0.7.2",
       "dependencies": {
+        "babel-runtime": {
+          "version": "4.7.16",
+          "dependencies": {
+            "core-js": {
+              "version": "0.6.1"
+            }
+          }
+        },
         "bluebird": {
           "version": "2.10.2"
         },
         "lodash-node": {
-          "version": "3.10.1"
+          "version": "3.10.2"
         },
         "markdown": {
           "version": "0.5.0",
@@ -41,7 +48,7 @@
       }
     },
     "lodash": {
-      "version": "4.0.0"
+      "version": "4.13.1"
     }
   }
 }

--- a/test/fixtures/demo/package.json
+++ b/test/fixtures/demo/package.json
@@ -9,7 +9,7 @@
   "author": "Contentful GmbH",
   "license": "MIT",
   "dependencies": {
-    "keepachangelog": "^0.7.0",
+    "keepachangelog": "^0.7.2",
     "lodash": "^4.0.0"
   }
 }

--- a/test/integration/bin/gitify-deps/with-environment-variables-test.js
+++ b/test/integration/bin/gitify-deps/with-environment-variables-test.js
@@ -45,7 +45,7 @@ describe('gitify-deps', function () {
     it('checks out the right git hash', function () {
       let hash = fs.readFileSync(`${changelogPath}/.git/HEAD`).toString().trim();
 
-      expect(hash).to.equal('bb747260fcdad8e52f8a98e4dfa273869027a071');
+      expect(hash).to.equal('eebd023c392a0b7fc5a6e0952e57be4d5485dd4e');
     });
 
     it('does not touch the lodash dependency', function () {

--- a/test/integration/bin/gitify-deps/with-gitify-url-pattern-option-test.js
+++ b/test/integration/bin/gitify-deps/with-gitify-url-pattern-option-test.js
@@ -41,7 +41,7 @@ describe('gitify-deps', function () {
     it('checks out the right git hash', function () {
       let hash = fs.readFileSync(`${changelogPath}/.git/HEAD`).toString().trim();
 
-      expect(hash).to.equal('bb747260fcdad8e52f8a98e4dfa273869027a071');
+      expect(hash).to.equal('eebd023c392a0b7fc5a6e0952e57be4d5485dd4e');
     });
 
     it('does not touch the lodash dependency', function () {


### PR DESCRIPTION
This PR fixes the scenario in which a package.json contains a repo url like `https://github.com/contentful-labs/keepachangelog.git`. 
For reasons that I don't understand myself, this gets transformed into `git+https://github.com/contentful-labs/keepachangelog.git` which causes `git clone` to fail later on. So instead of cloning this URL we are removing the `git+` prefix from the URL.